### PR TITLE
fix: always create new empty arrays

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -59,7 +59,8 @@ export async function reply(message: Message, options: string | ReplyMessageOpti
 }
 
 function resolvePayload(target: MessageTarget, options: string | Options, extra?: Options | undefined): Promise<MessagePayload> {
-	options = typeof options === 'string' ? { content: options, ...unsetValues } : { content: null, ...unsetValues, ...options };
+	options =
+		typeof options === 'string' ? { content: options, embeds: [], attachments: [] } : { content: null, embeds: [], attachments: [], ...options };
 	return MessagePayload.create(target, options, extra).resolveData().resolveFiles();
 }
 
@@ -78,11 +79,3 @@ async function sendPayload(message: Message, payload: MessagePayload): Promise<M
 }
 
 type Options = MessageOptions | WebhookMessageOptions;
-
-// This variable is casted like this (instead of `unsetValues: Options`) because `attachments` is a property on
-// `MessageEditOptions`, therefore it does not exist in `MessageOptions`. This makes the property non-assignable, and so
-// it can't be inlined with the other object spreads.
-//
-// As a workaround, I just define this object somewhere so we don't re-create it on each call. It is then casted to the
-// valid type. This way TypeScript is happy.
-const unsetValues = { embeds: [], attachments: [] } as Options;


### PR DESCRIPTION
Fixes a bug that will cause the library to have some funny behavior when `discord.js@13.4.0` is released due to https://github.com/discordjs/discord.js/pull/6871 mutating attachments, which will result on attachments to leak globally without this patch.
