### PR TITLE
fix: ensure messages retain components, files, and allowedMentions

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -63,7 +63,9 @@ export async function reply(message: Message, options: string | ReplyMessageOpti
 
 function resolvePayload(target: MessageTarget, options: string | Options, extra?: Options | undefined): Promise<MessagePayload> {
 	options =
-		typeof options === 'string' ? { content: options, embeds: [], attachments: [] } : { content: null, embeds: [], attachments: [], ...options };
+		typeof options === 'string'
+			? { content: options, embeds: [], attachments: [], components: [], files: [], allowedMentions: undefined }
+			: { content: null, embeds: [], attachments: [], components: [], files: [], allowedMentions: undefined, ...options };
 	return MessagePayload.create(target, options, extra).resolveData().resolveFiles();
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -64,8 +64,8 @@ export async function reply(message: Message, options: string | ReplyMessageOpti
 function resolvePayload(target: MessageTarget, options: string | Options, extra?: Options | undefined): Promise<MessagePayload> {
 	options =
 		typeof options === 'string'
-			? { content: options, embeds: [], attachments: [], components: [], files: [], allowedMentions: undefined }
-			: { content: null, embeds: [], attachments: [], components: [], files: [], allowedMentions: undefined, ...options };
+			? { content: options, embeds: [], attachments: [], components: [] }
+			: { content: null, embeds: [], attachments: [], components: [], ...options };
 	return MessagePayload.create(target, options, extra).resolveData().resolveFiles();
 }
 


### PR DESCRIPTION
This PR fixes the issues when makes the edited messages still retain the old components, files and allowedMentions options if any.